### PR TITLE
Update golang version

### DIFF
--- a/.final_builds/packages/golang-1-linux/index.yml
+++ b/.final_builds/packages/golang-1-linux/index.yml
@@ -1,6 +1,0 @@
-builds:
-  4f3c42aabef059e5de7860640cf39ff2b151ba32:
-    version: 4f3c42aabef059e5de7860640cf39ff2b151ba32
-    blobstore_id: aba10838-8791-47d4-6c0f-b9b2532d01ee
-    sha1: 547a22fa7d4c934397194c4657ed31586c4a1c60
-format-version: "2"

--- a/.final_builds/packages/golang-1.22-linux/index.yml
+++ b/.final_builds/packages/golang-1.22-linux/index.yml
@@ -1,0 +1,6 @@
+builds:
+  65e1dbda6b56080be4108e94c744f40bb2dca4caa417ab9fb376c2c353bdff1c:
+    version: 65e1dbda6b56080be4108e94c744f40bb2dca4caa417ab9fb376c2c353bdff1c
+    blobstore_id: 8daa7aba-1aea-489b-4a1a-dbf5804f8fde
+    sha1: sha256:7b20eaca465629e9195699e069545ab655584778c7b573f3f710e0f4915a3bf5
+format-version: "2"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @cloud-gov/customer-success-squad
+

--- a/packages/domain-broker/packaging
+++ b/packages/domain-broker/packaging
@@ -16,9 +16,8 @@ apt update && apt install -y git
 export GOBIN=${GOPATH}/bin
 export PATH=${GOBIN}:${PATH}
 mkdir -p ${GOBIN}
-curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
 pushd ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
-  dep ensure
   go install ${PACKAGE_NAME}/cmd/broker
   go install ${PACKAGE_NAME}/cmd/cron
 popd

--- a/packages/domain-broker/packaging
+++ b/packages/domain-broker/packaging
@@ -3,7 +3,7 @@
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 
 # Build CDN Service Broker package
 echo "Building Broker..."

--- a/packages/domain-broker/spec
+++ b/packages/domain-broker/spec
@@ -1,6 +1,6 @@
 ---
 name: domain-broker
 dependencies:
-  - golang-1-linux
+  - golang-1.22-linux
 files:
   - github.com/18F/cf-domain-broker-alb/**/*

--- a/packages/golang-1-linux/spec.lock
+++ b/packages/golang-1-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1-linux
-fingerprint: 4f3c42aabef059e5de7860640cf39ff2b151ba32

--- a/packages/golang-1.22-linux/spec.lock
+++ b/packages/golang-1.22-linux/spec.lock
@@ -1,0 +1,2 @@
+name: golang-1.22-linux
+fingerprint: 65e1dbda6b56080be4108e94c744f40bb2dca4caa417ab9fb376c2c353bdff1c


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update package for golang to use latest golang vendored release for 1.22

## security considerations

Updating BOSH release to use later veresion of Golang improves security
